### PR TITLE
Moved initialisation of laser pose

### DIFF
--- a/src/CLaserOdometry2DNode.cpp
+++ b/src/CLaserOdometry2DNode.cpp
@@ -104,8 +104,6 @@ CLaserOdometry2DNode::CLaserOdometry2DNode() :
     initial_robot_pose.pose.pose.orientation.z = 0;
   }
 
-  setLaserPoseFromTf();
-
   //Init variables
   module_initialized = false;
   first_laser_scan   = true;
@@ -196,6 +194,7 @@ void CLaserOdometry2DNode::LaserCallBack(const sensor_msgs::LaserScan::ConstPtr&
     }
     else
     {
+      setLaserPoseFromTf();
       init(last_scan, initial_robot_pose.pose.pose);
       first_laser_scan = false;
     }


### PR DESCRIPTION
Hey! Thanks for your good work on this port.

I was completely baffled because it worked first go, but the odometry was reversed. My laser tf is pointing backwards, so I assumed this had something to do with it.

Eventually I figured out that the laser pose tf was being requested based on `last_scan`, but at the time the object is created, that scan hasn't arrived yet, so the laser tf ends up being unity. I can see how this could be missed in testing if your laser faces forward.

My solution moves the pose initialisation until after the first scan is received. I can't see any downsides to this, but I don't know the code all that well.